### PR TITLE
Replace 'Private key' with 'Secret key' in myaddr.tools

### DIFF
--- a/website/myaddr.tools/claim.html
+++ b/website/myaddr.tools/claim.html
@@ -140,17 +140,17 @@
       </div>
       <div class="card-body">
         <div class="alert alert-info card-text">
-          The private key below allows anyone who has it to make updates to your domain. Keep it safe!
+          The secret key below allows anyone who has it to make updates to your domain. Keep it safe!
         </div>
       </div>
       <div class="card-body">
-        <label for="key-input" class="form-label">Your private key</label>
+        <label for="key-input" class="form-label">Your secret key</label>
         <div class="input-group">
           <input type="text" class="form-control" id="key-input" readonly>
           <button class="btn btn-outline-secondary" style="width: 6rem;" type="button" id="copy-button">Copy</button>
         </div>
         <div class="form-text">
-          Save your private key now. Once you leave this page, it is not possible to recover.
+          Save your secret key now. Once you leave this page, it is not possible to recover.
         </div>
       </div>
       <div class="card-body">

--- a/website/myaddr.tools/index.html
+++ b/website/myaddr.tools/index.html
@@ -44,9 +44,9 @@
     <li>ACME <code>dns-01</code> challenge support for TLS certificates from CAs like <a href="https://letsencrypt.org">Let's Encrypt</a></li>
   </ul>
   <h2>Getting Started</h2>
-  <p>First, <a href="/claim">claim your name</a>. If the name is available, you will be given a private key.</p>
-  <p>This private key gives whoever holds it control over that name. If you lose the private key, you lose the name.</p>
-  <p>With your private key, you can call the Update API to manage your DNS records.</p>
+  <p>First, <a href="/claim">claim your name</a>. If the name is available, you will be given a secret key.</p>
+  <p>This secret key gives whoever holds it control over that name. If you lose the secret key, you lose the name.</p>
+  <p>With your secret key, you can call the Update API to manage your DNS records.</p>
   <h2>Update API</h2>
   <p class="lead">Manage DNS records</p>
   <p>URL: <code>https://myaddr.tools/update</code><p>


### PR DESCRIPTION
The word "private key" conveys the idea that this this service is using asymmetric encryption (public/private keys).

I think it's better to use the word "secret key" as it's more a symmetric key that is known on both sides (your server and the client).